### PR TITLE
feat: create user records in db

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,8 @@
 import { NextAuthOptions } from "next-auth"
 import NextAuth from "next-auth/next"
 import GoogleProvider from "next-auth/providers/google"
+import connectToDB from "@/utils/connectToDB"
+import User from "@/models/user"
 
 export const authConfig: NextAuthOptions = {
   providers: [
@@ -8,7 +10,23 @@ export const authConfig: NextAuthOptions = {
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!
     })
-  ]
+  ],
+  callbacks: {
+    async signIn({ user: userInfo }) {
+      try {
+        await connectToDB()
+        await User.findOneAndUpdate(
+          { id: userInfo.id },
+          { id: userInfo.id, email: userInfo.email, name: userInfo.name },
+          { upsert: true, new: true, setDefaultsOnInsert: true }
+        )
+        return true
+      } catch (error) {
+        console.error("Could not save the user in the database")
+        return false
+      }
+    }
+  }
 }
 
 const handler = NextAuth(authConfig)

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,21 @@
+import { Schema, model, models } from "mongoose"
+
+const UserSchema = new Schema({
+  id: {
+    type: String,
+    required: true
+  },
+  name: {
+    type: String
+  },
+  email: {
+    type: String,
+    required: true
+  },
+  role: {
+    type: ["user", "admin"],
+    default: "user"
+  }
+})
+
+export default models.User || model("User", UserSchema)


### PR DESCRIPTION
## Description

Added a `signIn` callback function to create a user record in MongoDB when the user logs in for the first time via Google Provider. 

Closes #27 
## Type of change

Please delete options that are not relevant and add additional details as necessary.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation or comments)

## How Has This Been Tested?

1. In a logged-out state, click on the Log in button in the top nav bar to log in.
2. Go to the MongoDB [user collection](https://cloud.mongodb.com/v2/66b021d0c4943e680b3cabe7#/metrics/replicaSet/66b022d54159e857d2def42f/explorer/writegether-db/users/find) and ensure the new User record has been created.
3. Log out, and log in once again.
4. Ensure no duplicate record has been created.


